### PR TITLE
allow user to specify connection method to use

### DIFF
--- a/capistrano-asg.gemspec
+++ b/capistrano-asg.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'byebug'
 
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk-ec2', '~> 1'
+  spec.add_dependency 'aws-sdk-autoscaling', '~> 1'
   spec.add_dependency 'capistrano', '> 3.0.0'
   spec.add_dependency 'activesupport', '>= 4.0.0'
 end

--- a/lib/capistrano/asg.rb
+++ b/lib/capistrano/asg.rb
@@ -8,6 +8,7 @@ require 'capistrano/asg/retryable'
 require 'capistrano/asg/taggable'
 require 'capistrano/asg/logger'
 require 'capistrano/asg/aws/credentials'
+require 'capistrano/asg/aws/region'
 require 'capistrano/asg/aws/autoscaling'
 require 'capistrano/asg/aws/ec2'
 require 'capistrano/asg/aws_resource'
@@ -27,7 +28,7 @@ def autoscale(groupname, *args)
   include Capistrano::DSL
   include Capistrano::Asg::Aws::AutoScaling
   include Capistrano::Asg::Aws::EC2
-  
+
   connect_via = args[0].delete(:connect_via) || :private_ip_address
   autoscaling_group = autoscaling_resource.group(groupname)
   asg_instances = autoscaling_group.instances

--- a/lib/capistrano/asg.rb
+++ b/lib/capistrano/asg.rb
@@ -27,7 +27,8 @@ def autoscale(groupname, *args)
   include Capistrano::DSL
   include Capistrano::Asg::Aws::AutoScaling
   include Capistrano::Asg::Aws::EC2
-
+  
+  connect_via = args[0].delete(:connect_via) || :private_ip_address
   autoscaling_group = autoscaling_resource.group(groupname)
   asg_instances = autoscaling_group.instances
 
@@ -42,7 +43,7 @@ def autoscale(groupname, *args)
       puts "Autoscaling: Skipping unhealthy instance #{asg_instance.id}"
     else
       ec2_instance = ec2_resource.instance(asg_instance.id)
-      hostname = ec2_instance.private_ip_address
+      hostname = ec2_instance.send(connect_via.to_sym)
       puts "Autoscaling: Adding server #{hostname}"
       server(hostname, *args)
     end

--- a/lib/capistrano/asg.rb
+++ b/lib/capistrano/asg.rb
@@ -1,4 +1,5 @@
-require 'aws-sdk'
+require 'aws-sdk-ec2'
+require 'aws-sdk-autoscaling'
 require 'capistrano/all'
 require 'active_support/concern'
 
@@ -18,7 +19,6 @@ module Capistrano
   end
 end
 
-require 'aws-sdk'
 require 'capistrano/dsl'
 
 load File.expand_path('../asg/tasks/asg.rake', __FILE__)

--- a/lib/capistrano/asg/aws/autoscaling.rb
+++ b/lib/capistrano/asg/aws/autoscaling.rb
@@ -7,10 +7,11 @@ module Capistrano
       module AutoScaling
         extend ActiveSupport::Concern
         include Credentials
+        include Region
         include Capistrano::DSL
 
         def autoscaling_client
-          @_autoscaling_client ||= ::Aws::AutoScaling::Client.new(credentials)
+          @_autoscaling_client ||= ::Aws::AutoScaling::Client.new(region: region, credentials: credentials)
         end
 
         def autoscaling_resource

--- a/lib/capistrano/asg/aws/credentials.rb
+++ b/lib/capistrano/asg/aws/credentials.rb
@@ -8,11 +8,9 @@ module Capistrano
         include Capistrano::DSL
 
         def credentials
-          {
-            access_key_id:     fetch(:aws_access_key_id,     ENV['AWS_ACCESS_KEY_ID']),
-            secret_access_key: fetch(:aws_secret_access_key, ENV['AWS_SECRET_ACCESS_KEY']),
-            region:            fetch(:aws_region,            ENV['AWS_REGION'])
-          }
+          access_key_id = fetch(:aws_access_key_id, ENV['AWS_ACCESS_KEY_ID'])
+          secret_access_key = fetch(:aws_secret_access_key, ENV['AWS_SECRET_ACCESS_KEY'])
+          ::Aws::Credentials.new(access_key_id, secret_access_key)
         end
       end
     end

--- a/lib/capistrano/asg/aws/ec2.rb
+++ b/lib/capistrano/asg/aws/ec2.rb
@@ -7,6 +7,7 @@ module Capistrano
       module EC2
         extend ActiveSupport::Concern
         include Credentials
+        include Region
         include Capistrano::DSL
 
         def ec2_resource
@@ -20,7 +21,7 @@ module Capistrano
         private
 
         def ec2_client
-          ::Aws::EC2::Client.new(credentials)
+          ::Aws::EC2::Client.new(region: region, credentials: credentials)
         end
       end
     end

--- a/lib/capistrano/asg/aws/region.rb
+++ b/lib/capistrano/asg/aws/region.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Capistrano
+  module Asg
+    module Aws
+      module Region
+        extend ActiveSupport::Concern
+        include Capistrano::DSL
+
+        def region
+          fetch(:aws_region, ENV['AWS_REGION'])
+        end
+      end
+    end
+  end
+end

--- a/lib/capistrano/asg/aws_resource.rb
+++ b/lib/capistrano/asg/aws_resource.rb
@@ -22,7 +22,7 @@ module Capistrano
       private
 
       def base_ec2_instance
-        autoscaling_group.instances[0]
+        autoscaling_group.instances.first
       end
 
       def environment

--- a/lib/capistrano/asg/launch_configuration.rb
+++ b/lib/capistrano/asg/launch_configuration.rb
@@ -4,7 +4,7 @@ module Capistrano
     class LaunchConfiguration < AWSResource
       attr_reader :region_config
 
-      def self.create(ami, region_config, &_block)
+      def self.create(ami, region_config = {}, &_block)
         lc = new(region_config)
         lc.cleanup do
           lc.save(ami)


### PR DESCRIPTION
Allows the user to specify the method to call to get the ip/domain name to connect to. 
Might want to limit it to just the methods that are useful. But this works for my purposes. Just thought I would share.

Methods that are useful are
```
public_dns_name
private_dns_name
public_ip_address
private_ip_address
```

Usage:
```
autoscale 'asg-name', connect_via: :public_dns_name, roles: [:app, :web]
```