### PR TITLE
allow user to specify connection method to use

### DIFF
--- a/lib/capistrano/asg.rb
+++ b/lib/capistrano/asg.rb
@@ -27,7 +27,8 @@ def autoscale(groupname, *args)
   include Capistrano::DSL
   include Capistrano::Asg::Aws::AutoScaling
   include Capistrano::Asg::Aws::EC2
-
+  
+  connect_via = args[0].delete(:connect_via) || :private_ip_address
   autoscaling_group = autoscaling_resource.group(groupname)
   asg_instances = autoscaling_group.instances
 
@@ -42,7 +43,7 @@ def autoscale(groupname, *args)
       puts "Autoscaling: Skipping unhealthy instance #{asg_instance.id}"
     else
       ec2_instance = ec2_resource.instance(asg_instance.id)
-      hostname = ec2_instance.private_ip_address
+      hostname = ec2_instance.send(connect_via.to_sym)
       puts "Autoscaling: Adding server #{hostname}"
       server(hostname, *args)
     end


### PR DESCRIPTION
Allows the user to specify the method to call to get the ip/domain name to connect to.
Might want to limit it to just the methods that are useful. But this works for my purposes. Just thought I would share. It will default to the current behaviour.

Methods that are useful are
```
public_dns_name
private_dns_name
public_ip_address
private_ip_address
```

Usage:
```
autoscale 'asg-name', connect_via: :public_dns_name, roles: [:app, :web]
```