### PR TITLE
Scale after finished.

### DIFF
--- a/lib/capistrano/asg.rb
+++ b/lib/capistrano/asg.rb
@@ -50,7 +50,7 @@ def autoscale(groupname, *args)
   end
 
   if asg_instances.count > 0 && fetch(:create_ami, true)
-    after('deploy:finishing', 'asg:scale')
+    after('deploy:finished', 'asg:scale')
   else
     puts 'Autoscaling: AMI could not be created because no running instances were found.\
       Is your autoscale group name correct?'


### PR DESCRIPTION
Fails when `aws_no_reboot_on_create_ami: false` because the connection is dropped before we're finished deploying.