### PR TITLE
Add :partial_roles to run on a subset of instances in the ASG

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ regions.each do |region|
 end
 ```
 
+If you want to specify roles for a subset of instances in the autoscaling group, you can use
+`:partial_roles`.  These will be spread out 1 per server:
+
+```ruby
+autoscale 'asg-app', user: 'apps', roles: [:app, :web],
+  partial_roles: [
+    { name: :migrate, instances: 1 },
+    { name: :sidekiq, instances: 2 }
+  ]
+```
+
 The name of the newly created launch configurations are available via `fetch(:asg_launch_config)`.
 This is a two-dimensional hash with region and autoscaling group name as keys.
 You can output these or store them as necessary in an `after 'deploy:finished'` hook.

--- a/lib/capistrano/asg.rb
+++ b/lib/capistrano/asg.rb
@@ -24,7 +24,7 @@ require 'capistrano/dsl'
 
 load File.expand_path('../asg/tasks/asg.rake', __FILE__)
 
-def autoscale(groupname, *args)
+def autoscale(groupname, **args)
   include Capistrano::DSL
   include Capistrano::Asg::Aws::AutoScaling
   include Capistrano::Asg::Aws::EC2
@@ -38,6 +38,16 @@ def autoscale(groupname, *args)
   (regions[region] ||= []) << groupname
   set :regions, regions
 
+  # Create an array of role names to be distributed across the ASG
+  partial_queue = []
+  if args.key?(:partial_roles)
+    args[:partial_roles].each do |partial|
+      instances = partial.key?(:instances) ? partial[:instances] : 1
+      instances.times { partial_queue << partial[:name].to_s }
+    end
+    args.delete(:partial_roles)
+  end
+
   asg_instances.each do |asg_instance|
     if asg_instance.health_status != 'Healthy'
       puts "Autoscaling: Skipping unhealthy instance #{asg_instance.id}"
@@ -45,15 +55,24 @@ def autoscale(groupname, *args)
       ec2_instance = ec2_resource.instance(asg_instance.id)
       hostname = ec2_instance.private_ip_address
       puts "Autoscaling: Adding server #{hostname}"
-      server(hostname, *args)
+      # create a complete temp copy of the array contents instead of just copying the references
+      host_args = Marshal.load(Marshal.dump(args))
+      if additional_role = partial_queue.shift
+        host_args[:roles] << additional_role
+      end
+      server(hostname, **host_args)
     end
   end
 
-  if asg_instances.count > 0 && fetch(:create_ami, true)
-    after('deploy:finishing', 'asg:scale')
-  else
-    puts 'Autoscaling: AMI could not be created because no running instances were found.\
-      Is your autoscale group name correct?'
+  puts "WARNING: Not all partial roles were assigned: #{partial_queue}" unless partial_queue.empty?
+
+  if fetch(:create_ami, true)
+    if asg_instances.count > 0
+      after('deploy:finishing', 'asg:scale')
+    else
+      puts 'Autoscaling: AMI could not be created because no running instances were found.\
+        Is your autoscale group name correct?'
+    end
   end
 
   reset_autoscaling_objects


### PR DESCRIPTION
We have db's on aurora, so we don't have a single server to run migrations from.  This adds a basic ability to limit roles to a certain number of instances.  Thinking about expanding this to a percentage of the running instances down the line, but this meets our immediate needs.  Also some corner cases to watch out for as instances and ordering change.

Happy to discuss different implementations, naming, whatever!

While I was there I also fixed a spurious warning when `:create_ami` is false