### PR TITLE
Fetch ARN only if iam_instance_profile attached

### DIFF
--- a/lib/capistrano/asg/launch_configuration.rb
+++ b/lib/capistrano/asg/launch_configuration.rb
@@ -31,7 +31,7 @@ module Capistrano
               enabled: fetch(:aws_launch_configuration_detailed_instance_monitoring, true)
             },
             user_data: region_config.fetch(:aws_launch_configuration_user_data, nil),
-            iam_instance_profile: ec2_instance.iam_instance_profile.arn
+            iam_instance_profile: ec2_instance.iam_instance_profile&.arn
           )
         end
       end


### PR DESCRIPTION
Internally we had to attach this safe fetching of the iam_instance_profile cause sometimes our EC2 instances didnt had any iam profile attached to it, making the launch configuration build to fail.

Its a pretty simple change we had to do to make it work.