### PR TITLE
Update Bundler Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.1
+
+* update development dependency `bundler` to minimum version `2.0.0`
+
 # 0.8.0
 **Breaking Change**
 * Change name of the configuration options hash to include both the AWS region and

--- a/capistrano-asg.gemspec
+++ b/capistrano-asg.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['logan.serman@metova.com', 'jeff.fraser@veracross.com', 'michael.martell@veracross.com']
   spec.summary       = 'Capistrano plugin for deploying to AWS AutoScale Groups.'
   spec.description   = "#{spec.summary} Deploys to all instances in a group, creates a fresh AMI post-deploy, and attaches the AMI to your AutoScale Group."
-  spec.homepage      = 'http://github.com/sixfeetover/capistrano-asg'
+  spec.homepage      = 'http://github.com/veracross/capistrano-asg'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler', '>= 2.0.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'webmock'

--- a/lib/capistrano/asg/version.rb
+++ b/lib/capistrano/asg/version.rb
@@ -2,6 +2,6 @@
 
 module Capistrano
   module Asg
-    VERSION = '0.8.0'
+    VERSION = '0.8.1'
   end
 end


### PR DESCRIPTION
### Background

Updating the version number for the development dependency of `bundler`. We should be using a minimum version of `2.0.0`.


### Test Plan

Confirm changes work locally for development:

```
bundle install
bundle exec rake install # verify gem installation works
```

In your app, update your gemfile to reference new local version (`0.8.1`) and confirm your deploy commands still work.